### PR TITLE
fix "Illegal Invocation" error when calling storage getItrem/setItem

### DIFF
--- a/scripts/index.inline.js
+++ b/scripts/index.inline.js
@@ -1,6 +1,6 @@
 opera.isReady(function() {
   (function() {
-    var storage = widget.preferences;
+    var storage = widget.preferences._storage;
     var browserLang = window.navigator.language;
     var homeLang = storage.getItem( 'homeLang' ) ||
         ( NAME_MAP[ browserLang ] ? browserLang : 'en' );

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -35,7 +35,7 @@ opera.isReady(function() {
     }
   };
   window.addEventListener('DOMContentLoaded', function() {
-    var storage = widget.preferences;
+    var storage = widget.preferences._storage;
 
     function optionChanged(e) {
       var element = e.currentTarget;


### PR DESCRIPTION
Just a quick (and dirty) fix for the exception that crashes the extension in Opera 50+.